### PR TITLE
Add PTZ command and tile layout with RTSP playback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
+    implementation 'com.android.support:recyclerview-v7:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
                 "screenSize|smallestScreenSize|screenLayout|orientation"
 
             ></activity>
+        <activity android:name="com.rvirin.onvif.demo.TileActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/rvirin/onvif/demo/CameraTile.kt
+++ b/app/src/main/java/com/rvirin/onvif/demo/CameraTile.kt
@@ -1,0 +1,3 @@
+package com.rvirin.onvif.demo
+
+data class CameraTile(val rtspUrl: String)

--- a/app/src/main/java/com/rvirin/onvif/demo/CameraTileAdapter.kt
+++ b/app/src/main/java/com/rvirin/onvif/demo/CameraTileAdapter.kt
@@ -1,0 +1,48 @@
+package com.rvirin.onvif.demo
+
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.TextureView
+import android.view.View
+import android.view.ViewGroup
+import com.pedro.vlc.VlcListener
+import com.pedro.vlc.VlcVideoLibrary
+import com.rvirin.onvif.R
+
+class CameraTileAdapter(private val items: List<CameraTile>) :
+    RecyclerView.Adapter<CameraTileAdapter.TileViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TileViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_camera_tile, parent, false)
+        return TileViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: TileViewHolder, position: Int) {
+        val tile = items[position]
+        // stop any previous playback before starting a new one
+        holder.player?.stop()
+
+        holder.player = VlcVideoLibrary(holder.itemView.context, holder, holder.texture)
+        holder.player?.play(tile.rtspUrl)
+    }
+
+    override fun onViewRecycled(holder: TileViewHolder) {
+        super.onViewRecycled(holder)
+        holder.player?.stop()
+        holder.player = null
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class TileViewHolder(view: View) : RecyclerView.ViewHolder(view), VlcListener {
+        val texture: TextureView = view.findViewById(R.id.tileTexture)
+        var player: VlcVideoLibrary? = null
+
+        override fun onComplete() {}
+
+        override fun onError() {
+            player?.stop()
+        }
+    }
+}

--- a/app/src/main/java/com/rvirin/onvif/demo/TileActivity.kt
+++ b/app/src/main/java/com/rvirin/onvif/demo/TileActivity.kt
@@ -1,0 +1,18 @@
+package com.rvirin.onvif.demo
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.GridLayoutManager
+import android.support.v7.widget.RecyclerView
+import com.rvirin.onvif.R
+
+class TileActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tile)
+
+        val recycler = findViewById<RecyclerView>(R.id.recyclerView)
+        recycler.layoutManager = GridLayoutManager(this, 2)
+        recycler.adapter = CameraTileAdapter(emptyList())
+    }
+}

--- a/app/src/main/res/layout/activity_tile.xml
+++ b/app/src/main/res/layout/activity_tile.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/item_camera_tile.xml
+++ b/app/src/main/res/layout/item_camera_tile.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="2dp">
+
+    <TextureView
+        android:id="@+id/tileTexture"
+        android:layout_width="match_parent"
+        android:layout_height="120dp" />
+</FrameLayout>

--- a/onvifcamera/src/main/java/com/rvirin/onvif/onvifcamera/OnvifPTZ.kt
+++ b/onvifcamera/src/main/java/com/rvirin/onvif/onvifcamera/OnvifPTZ.kt
@@ -1,0 +1,15 @@
+package com.rvirin.onvif.onvifcamera
+
+object OnvifPTZ {
+    fun continuousMoveCommand(profileToken: String, pan: Float, tilt: Float, zoom: Float): String {
+        return OnvifXMLBuilder.soapHeader +
+                "<ContinuousMove xmlns=\"http://www.onvif.org/ver20/ptz/wsdl\">" +
+                "<ProfileToken>$profileToken</ProfileToken>" +
+                "<Velocity>" +
+                "<PanTilt x=\"$pan\" y=\"$tilt\" xmlns=\"http://www.onvif.org/ver10/schema\"/>" +
+                "<Zoom x=\"$zoom\" xmlns=\"http://www.onvif.org/ver10/schema\"/>" +
+                "</Velocity>" +
+                "</ContinuousMove>" +
+                OnvifXMLBuilder.envelopeEnd
+    }
+}

--- a/onvifcamera/src/main/java/com/rvirin/onvif/onvifcamera/OnvifServices.kt
+++ b/onvifcamera/src/main/java/com/rvirin/onvif/onvifcamera/OnvifServices.kt
@@ -9,6 +9,7 @@ import java.io.StringReader
 import com.rvirin.onvif.onvifcamera.OnvifRequest.Type.GetDeviceInformation
 import com.rvirin.onvif.onvifcamera.OnvifRequest.Type.GetProfiles
 import com.rvirin.onvif.onvifcamera.OnvifRequest.Type.GetStreamURI
+import com.rvirin.onvif.onvifcamera.OnvifRequest.Type.PtzContinuousMove
 import java.net.MalformedURLException
 import java.net.URL
 
@@ -49,6 +50,9 @@ class OnvifServices {
                             val uri = retrieveXAddr(xpp)
                             paths.profiles = retrievePath(uri)
                             paths.streamURI = retrievePath(uri)
+                        } else if (currentNamespace == PtzContinuousMove.namespace()) {
+                            val uri = retrieveXAddr(xpp)
+                            paths.ptz = retrievePath(uri)
                         }
                     }
 


### PR DESCRIPTION
## Summary
- extend ONVIF device with PTZ continuous move request
- add RecyclerView based tile layout for camera streams
- enable RTSP playback per tile with libVLC and release streams on recycle

## Testing
- `./gradlew test` *(fails: Could not determine java version from '21.0.2')*
- `apt-get install -y openjdk-11-jdk` *(fails: Unable to locate package openjdk-11-jdk)*

------
https://chatgpt.com/codex/tasks/task_e_688ef2da5624832a85a6edee9ec633d0