### PR TITLE
Replace deprecated jcenter repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,11 @@ buildscript {
     ext.kotlin_version = '1.2.30'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        // jcenter() has been removed in recent Gradle versions; use the legacy
+        // repository URL directly to resolve any remaining dependencies that
+        // were historically hosted there.
+        maven { url 'https://jcenter.bintray.com/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
@@ -21,7 +25,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url 'https://jcenter.bintray.com/' }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated `jcenter()` repository declarations with `mavenCentral()` and a direct legacy JCenter URL
- keep access to artifacts previously hosted on JCenter without relying on removed DSL methods

## Testing
- `./gradlew tasks` *(fails: Could not determine java version from '21.0.2')*


------
https://chatgpt.com/codex/tasks/task_e_688ef667dca0832aab5876e70aae8910