### PR TITLE
docs: note supported Java version for plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+//
+// NOTE: The Android Gradle plugin (3.1.0) and Kotlin plugin (1.2.30) used in this
+// project do not support running on Java 21. Use Java 8 (or another compatible
+// version) to avoid build failures.
 
 buildscript {
     ext.kotlin_version = '1.2.30'


### PR DESCRIPTION
## Summary
- warn that AGP 3.1.0 and Kotlin 1.2.30 don't support Java 21
- recommend using Java 8 for building

## Testing
- `./gradlew -q tasks` *(fails: Could not determine java version from '21.0.2')*

------
https://chatgpt.com/codex/tasks/task_e_688ef7f7293c832a8fc742d747912c5c