### PR TITLE
Remove deprecated maven plugin causing Gradle init failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,13 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        // The project previously applied the deprecated
+        // "android-maven-gradle-plugin" to publish artifacts. This plugin pulls
+        // in classes such as `BuildCompletionListener` that are unavailable in
+        // the legacy Gradle version bundled with the repository and caused
+        // builds to fail during initialisation. Removing the dependency avoids
+        // loading the incompatible plugin while keeping the existing build
+        // configuration intact.
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/install-v1.gradle
+++ b/gradle/install-v1.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.github.dcendents.android-maven'
+// This auxiliary script previously applied the deprecated
+// `com.github.dcendents.android-maven` plugin to publish artifacts. The plugin
+// is no longer used in the project to avoid dependency on outdated Gradle
+// APIs that triggered BuildCompletionListener-related errors.
 
 group = publishedGroupId                               // Maven Group ID for the artifact
 

--- a/libvlc/build.gradle
+++ b/libvlc/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-group = 'com.github.pedroSG94'
+
+// Remove the deprecated `android-maven` plugin which required unavailable
+// Gradle internals and caused build failures. Publishing is not needed for the
+// library inside this repository, so the plugin and its `group` declaration
+// have been omitted.
 
 android {
   compileSdkVersion 27

--- a/pedrovlc/build.gradle
+++ b/pedrovlc/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-group = 'com.github.pedroSG94'
+
+// The original build used the deprecated `android-maven` plugin to publish
+// artifacts. It depends on Gradle internals that are no longer available and
+// triggered "Unable to load class 'org.gradle.initialization.BuildCompletionListener'".
+// Since publishing is not required for building or running the sample, the
+// plugin and associated `group` declaration have been removed.
 
 android {
     compileSdkVersion 27


### PR DESCRIPTION
## Summary
- drop `android-maven-gradle-plugin` usage that referenced unavailable Gradle internals and triggered `BuildCompletionListener` errors during build
- clean up library build scripts and auxiliary installation script accordingly

## Testing
- `./gradlew --version` *(fails: Could not determine java version from '21.0.2')*


------
https://chatgpt.com/codex/tasks/task_e_688efdc4f82c832ab02af1dbe91a54a1