### PR TITLE
docs: clarify gradle requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ An Android app for viewing ONVIF camera's. Users can take screenshot of video wh
 
 This app was selected in Top 10 and an award of $800 was given to this application [Link to blog](https://www.onvif.org/blog/2018/07/onvif-challenge-announces-top-10/)
 
+## Building
+
+The project targets a very early version of the Android Gradle plugin
+(`3.1.0`) and therefore requires both **Gradle 4.x** and a **JDK 8** runtime.
+Attempting to open the project with a newer Gradle distribution (for example
+the one bundled with recent Android Studio versions) leads to errors such as
+`Could not create an instance of type com.android.build.gradle.AppExtension`.
+
+To build from the command line use the included wrapper and ensure `JAVA_HOME`
+points to a JDK 8 installation:
+
+```bash
+JAVA_HOME=/path/to/jdk8 ./gradlew assembleDebug
+```
+
 ## Publishing
 
 Legacy scripts for publishing the library to JFrog Bintray have been removed and are no longer used.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,21 @@
+import org.gradle.util.GradleVersion
+
+// The build relies on the Android Gradle plugin 3.1.0 which only works with
+// Gradle 4.x and a Java 8 runtime.  Running the project with a newer Gradle
+// distribution (for example the one bundled with recent Android Studio
+// releases) leads to startup failures such as:
+//
+//   "Could not create an instance of type com.android.build.gradle.AppExtension"
+//
+// Provide a clearer error message when a newer Gradle version is detected so
+// developers know to use the bundled `./gradlew` script together with a JDK 8
+// installation.
+if (GradleVersion.current() >= GradleVersion.version('5.0')) {
+    throw new GradleException(
+        "Unsupported Gradle version ${GradleVersion.current()}. " +
+        "Run the project using the provided ./gradlew script and a JDK 8 runtime."
+    )
+}
+
 include ':app', ':onvifcamera', ':libvlc', ':pedrovlc'
+


### PR DESCRIPTION
## Summary
- document required Gradle/JDK versions and how to build
- fail fast when opening project with unsupported Gradle versions

## Testing
- `gradle tasks` *(fails: Unsupported Gradle version Gradle 8.14.3. Run the project using the provided ./gradlew script and a JDK 8 runtime.)*
- `./gradlew tasks` *(fails: Could not determine java version from '21.0.2'.)*

------
https://chatgpt.com/codex/tasks/task_e_688f050a8144832a81c1d0666c86b460